### PR TITLE
Patch 2

### DIFF
--- a/display_four_times.v
+++ b/display_four_times.v
@@ -1,0 +1,67 @@
+`timescale 1ns / 1ps
+//////////////////////////////////////////////////////////////////////////////////
+// Company: 
+// Engineer: 
+// 
+// Create Date:    18:19:45 05/10/2017 
+// Design Name: 
+// Module Name:    display_four_times 
+// Project Name: 
+// Target Devices: 
+// Tool versions: 
+// Description: 
+//
+// Dependencies: 
+//
+// Revision: 
+// Revision 0.01 - File Created
+// Additional Comments: 
+//
+//////////////////////////////////////////////////////////////////////////////////
+module display_four_times(
+    input [3:0] min1_digit,
+    input [3:0] min0_digit,
+    input [3:0] sec1_digit,
+    input [3:0] sec0_digit,
+	 input [3:0] anode,
+	 input superfast_hz,
+    output [7:0] min1_out,
+    output [7:0] min0_out,
+    output [7:0] sec1_out,
+    output [7:0] sec0_out
+    );
+
+	display_time min1(
+		.digit_in(min1_digit),
+		.seg_out(min1_out)
+		);
+		
+	display_time min0(
+		.digit_in(min0_digit),
+		.seg_out(min0_out)
+		);
+		
+	display_time sec1(
+		.digit_in(sec1_digit),
+		.seg_out(sec1_out)
+		);
+		
+	display_time sec0(
+		.digit_in(sec0_digit),
+		.seg_out(sec0_out)
+		);
+		
+		always @(posedge superfast_hz) 
+		begin
+			anode = 4'b0111;
+			min1_out = min1;
+			anode = 4'b1011;
+			min0_out = min0;
+			anode = 4'b1101;
+			sec1_out = sec1;
+			anode = 4'b1110;
+			sec0_out = sec0;
+		end
+	
+
+endmodule

--- a/display_tb.v
+++ b/display_tb.v
@@ -86,6 +86,7 @@ module display_tb;
 				end
 			end
 		end
+		$finish;
 
 	end
       

--- a/display_tb.v
+++ b/display_tb.v
@@ -4,9 +4,9 @@
 // Company: 
 // Engineer:
 //
-// Create Date:   11:29:51 05/09/2017
+// Create Date:   06:56:02 05/11/2017
 // Design Name:   display_time
-// Module Name:   C:/Users/152/Desktop/lab3/lab3/display_tb.v
+// Module Name:   C:/Users/raz/Downloads/m152a-lab3-joealbert5-patch-1/m152a-lab3-joealbert5-patch-1/display_tb.v
 // Project Name:  lab3
 // Target Device:  
 // Tool versions:  
@@ -33,24 +33,20 @@ module display_tb;
 
 	// Outputs
 	wire [3:0] an_out;
-	 wire [7:0] min1_out;
-	 wire [7:0] min0_out;
-	 wire [7:0] sec1_out;
-	 wire [7:0] sec0_out;
+	wire [7:0] seg_out;
 
 	// Instantiate the Unit Under Test (UUT)
 	display_time uut (
-		.min1_in(min1), 
-		.min0_in(min0), 
-		.sec1_in(sec1), 
-		.sec0_in(sec0), 
+		.min1(min1), 
+		.min0(min0), 
+		.sec1(sec1), 
+		.sec0(sec0), 
 		.clk(clk), 
-		.min1_out(min1_out), 
-		.min0_out(min0_out),
-		.sec1_out(sec1_out),
-		.sec0_out(sec0_out)
+		.an(an_out), 
+		.seg(seg_out)
 	);
 	integer i;
+	integer j;
 	initial begin
 		// Initialize Inputs
 		min1 = 0;
@@ -63,14 +59,15 @@ module display_tb;
 		#100;
         
 		// Add stimulus here
-		sec0 = 1;
+		j = 0;
 		for (i = 0; i < 1000000000; i = i + 1)
 		begin
 			clk = ~clk;
-			#10;
+			#20;
+			j = j + 1;
 			//always@ (posedge clk) 
 			begin
-				if (clk) 
+				if (j == 30) 
 				begin
 					sec0 = sec0 + 1;
 					if (sec0 == 10) begin
@@ -85,10 +82,12 @@ module display_tb;
 						min1 = min1 + 1;
 						min1 = 0;
 					end
+					j = 0;
 				end
 			end
 		end
-			$finish;
-     end 
+
+	end
+      
 endmodule
 

--- a/display_tb.v
+++ b/display_tb.v
@@ -32,18 +32,23 @@ module display_tb;
 	reg clk;
 
 	// Outputs
-	wire [3:0] an;
-	wire [7:0] seg;
+	wire [3:0] an_out;
+	 wire [7:0] min1_out;
+	 wire [7:0] min0_out;
+	 wire [7:0] sec1_out;
+	 wire [7:0] sec0_out;
 
 	// Instantiate the Unit Under Test (UUT)
 	display_time uut (
-		.min1(min1), 
-		.min0(min0), 
-		.sec1(sec1), 
-		.sec0(sec0), 
+		.min1_in(min1), 
+		.min0_in(min0), 
+		.sec1_in(sec1), 
+		.sec0_in(sec0), 
 		.clk(clk), 
-		.an_out(an), 
-		.seg_out(seg)
+		.min1_out(min1_out), 
+		.min0_out(min0_out),
+		.sec1_out(sec1_out),
+		.sec0_out(sec0_out)
 	);
 	integer i;
 	initial begin
@@ -63,9 +68,27 @@ module display_tb;
 		begin
 			clk = ~clk;
 			#10;
+			//always@ (posedge clk) 
+			begin
+				if (clk) 
+				begin
+					sec0 = sec0 + 1;
+					if (sec0 == 10) begin
+						sec1 = sec1 + 1;
+						sec0 = 0;
+					end
+					if (sec1 == 6) begin
+						min0 = min0 + 1;
+						sec1 = 0;
+					end
+					if (min0 == 10) begin
+						min1 = min1 + 1;
+						min1 = 0;
+					end
+				end
+			end
 		end
-		$finish;
-	end
-      
+			$finish;
+     end 
 endmodule
 

--- a/display_time.v
+++ b/display_time.v
@@ -19,26 +19,120 @@
 //
 //////////////////////////////////////////////////////////////////////////////////
 module display_time(
-    input [3:0] digit_in,
-	 output [7:0] seg_out
+    input [2:0] min1,
+    input [3:0] min0,
+    input [2:0] sec1,
+    input [3:0] sec0,
+	 input clk,
+	 output reg [3:0] an,
+	 output reg [7:0] seg
     );
-	  reg [7:0] digit;
 	 
+	 integer j = 0;
+	
 	 always@ (posedge clk) begin
-		case(digit_in)
-			4'b0000: digit = 8'b11000000;
-			4'b0001: digit = 8'b11111001;
-			4'b0010: digit = 8'b10100100;
-			4'b0011: digit = 8'b10110000;
-			4'b0100: digit = 8'b10011001;
-			4'b0101: digit = 8'b10010010;
-			4'b0110: digit = 8'b10000010;
-			4'b0111: digit = 8'b11111000;
-			4'b1000: digit = 8'b10000000;
-			4'b1001: digit = 8'b10010000;
-		endcase
-	end
+		if (j == 0)
+		begin
+			an = 15;
+			seg = 255;
+		end
+	 
+		// sec0
+		if (j == 1)
+		begin
+			an = 14;
+			case(sec0)
+				0: seg = 192; // zero
+				1: seg = 249; // one
+				2: seg = 164; // is this format faster?
+				3: seg = 176;
+				4: seg = 153;
+				5: seg = 146;
+				6: seg = 130;
+				7: seg = 248;
+				8: seg = 128;
+				9: seg = 144;
+			endcase
+		end
+		else if (j == 2)
+		begin
+			an = 15;
+			seg = 255;
+		end
 		
-	assign seg_out = digit;
+		// sec1
+		if (j == 3)
+		begin
+			an = 13;
+			case(sec1)
+				0: seg = 192;
+				1: seg = 249;
+				2: seg = 164;
+				3: seg = 176;
+				4: seg = 153;
+				5: seg = 146;
+				6: seg = 130;
+				7: seg = 248;
+				8: seg = 128;
+				9: seg = 144;
+			endcase
+		end
+		if (j == 4)
+		begin
+			an = 15;
+			seg = 255;
+		end
+		
+		// min0
+		if (j == 5)
+		begin
+			an = 11;
+			case(min0)
+				0: seg = 192;
+				1: seg = 249;
+				2: seg = 164;
+				3: seg = 176;
+				4: seg = 153;
+				5: seg = 146;
+				6: seg = 130;
+				7: seg = 248;
+				8: seg = 128;
+				9: seg = 144;
+			endcase
+		end
+		if (j == 6)
+		begin
+			an = 15;
+			seg = 255;
+		end
+		
+		// min1
+		
+		if (j == 7)
+		begin
+			an = 7;
+			case(min1)
+				0: seg = 192;
+				1: seg = 249;
+				2: seg = 164;
+				3: seg = 176;
+				4: seg = 153;
+				5: seg = 146;
+				6: seg = 130;
+				7: seg = 248;
+				8: seg = 128;
+				9: seg = 144;
+			endcase
+		end
+		if (j == 8)
+		begin
+			an = 15;
+			seg = 255;
+			j = -1;
+		end
+		
+		j = j + 1;
+		
+	 end
 			
 endmodule

--- a/display_time.v
+++ b/display_time.v
@@ -19,238 +19,26 @@
 //
 //////////////////////////////////////////////////////////////////////////////////
 module display_time(
-    input [2:0] min1,
-    input [3:0] min0,
-    input [2:0] sec1,
-    input [3:0] sec0,
-	 input clk,
-	 output [3:0] an_out,
+    input [3:0] digit_in,
 	 output [7:0] seg_out
     );
-	 
-	  reg [3:0] an;
-	  reg [7:0] seg;
+	  reg [7:0] digit;
 	 
 	 always@ (posedge clk) begin
-		
-		an[0] = 0;
-		if (sec0 == 1)
-		begin
-			seg[0]=0;
-			seg[1]=0;
-			seg[2]=0;
-			seg[3]=0;
-			seg[4]=0;
-			seg[5]=0;
-			seg[6]=1;
-		end
-		case(sec0)
-			0: zero;
-			1: one;
-			2: two;
-			3: three;
-			4: four;
-			5: five;
-			6: six;
-			7: seven;
-			8: eight;
-			9: nine;
+		case(digit_in)
+			4'b0000: digit = 8'b11000000;
+			4'b0001: digit = 8'b11111001;
+			4'b0010: digit = 8'b10100100;
+			4'b0011: digit = 8'b10110000;
+			4'b0100: digit = 8'b10011001;
+			4'b0101: digit = 8'b10010010;
+			4'b0110: digit = 8'b10000010;
+			4'b0111: digit = 8'b11111000;
+			4'b1000: digit = 8'b10000000;
+			4'b1001: digit = 8'b10010000;
 		endcase
-		an[0] = 1;
-
-		
-		an[1] = 0;
-		case(sec1)
-			0: zero;
-			1: one;
-			2: two;
-			3: three;
-			4: four;
-			5: five;
-			6: six;
-			7: seven;
-			8: eight;
-			9: nine;
-		endcase
-		an[1] = 1;
-	
-		
-		an[2] = 0;
-		case(min0)
-			0: zero;
-			1: one;
-			2: two;
-			3: three;
-			4: four;
-			5: five;
-			6: six;
-			7: seven;
-			8: eight;
-			9: nine;
-		endcase
-		an[2] = 1;
-
-		
-		an[3] = 0;
-		case(min1)
-			0: zero;
-			1: one;
-			2: two;
-			3: three;
-			4: four;
-			5: five;
-			6: six;
-			7: seven;
-			8: eight;
-			9: nine;
-		endcase
-		an[3] = 1;
-		
-		
-		an[0] = 0;
-		an[1] = 0;
-		an[2] = 0;
-		an[3] = 0;
-		clear;
-		an[0] = 1;
-		an[1] = 1;
-		an[2] = 1;
-		an[3] = 1;
-	 end
-	 
-	 task zero;
-		begin
-			seg[0]=0;
-			seg[1]=0;
-			seg[2]=0;
-			seg[3]=0;
-			seg[4]=0;
-			seg[5]=0;
-			seg[6]=1;
-		end
-	endtask
-	
-	task one;
-	begin
-			seg[0]=1;
-			seg[1]=0;
-			seg[2]=0;
-			seg[3]=1;
-			seg[4]=1;
-			seg[5]=1;
-			seg[6]=1;
-		end
-	endtask
-	
-	task two;
-	begin
-			seg[0]=0;
-			seg[1]=0;
-			seg[2]=1;
-			seg[3]=0;
-			seg[4]=0;
-			seg[5]=1;
-			seg[6]=0;
-		end
-	endtask
-	
-	task three;
-	begin
-			seg[0]=0;
-			seg[1]=0;
-			seg[2]=0;
-			seg[3]=0;
-			seg[4]=1;
-			seg[5]=1;
-			seg[6]=0;
-		end
-	endtask
-	
-	task four;
-	begin
-			seg[0]=1;
-			seg[1]=0;
-			seg[2]=0;
-			seg[3]=1;
-			seg[4]=1;
-			seg[5]=0;
-			seg[6]=0;
-		end
-	endtask
-	
-	task five;
-	begin
-			seg[0]=0;
-			seg[1]=1;
-			seg[2]=0;
-			seg[3]=0;
-			seg[4]=1;
-			seg[5]=0;
-			seg[6]=0;
-		end
-	endtask
-	
-	task six;
-	begin
-			seg[0]=0;
-			seg[1]=1;
-			seg[2]=0;
-			seg[3]=0;
-			seg[4]=0;
-			seg[5]=0;
-			seg[6]=0;
-		end
-	endtask
-	
-	task seven;
-	begin
-			seg[0]=0;
-			seg[1]=0;
-			seg[2]=0;
-			seg[3]=1;
-			seg[4]=1;
-			seg[5]=1;
-			seg[6]=1;
-		end
-	endtask
-	
-	task eight;
-	begin
-			seg[0]=0;
-			seg[1]=0;
-			seg[2]=0;
-			seg[3]=0;
-			seg[4]=0;
-			seg[5]=0;
-			seg[6]=0;
-		end
-	endtask
-	
-	task nine;
-	begin
-			seg[0]=0;
-			seg[1]=0;
-			seg[2]=0;
-			seg[3]=0;
-			seg[4]=1;
-			seg[5]=0;
-			seg[6]=0;
-		end
-	endtask
-	
-	task clear;
-	begin
-			seg[0]=1;
-			seg[1]=1;
-			seg[2]=1;
-			seg[3]=1;
-			seg[4]=1;
-			seg[5]=1;
-			seg[6]=1;
 	end
-	endtask
-	
-	assign an_out = an;
-	assign seg_out = seg;
+		
+	assign seg_out = digit;
 			
 endmodule


### PR DESCRIPTION
display_time.v:
1. changed the outputs to registers
2. used decimal notation to change "seg" and "an" (thought it would be cleaner and faster)
3. removed all the tasks since they were unnecessary
4. each anode (w/ seg) is updated in order every 8 clock cycles
(anode 0 set, clear, anode 1 set, clear, anode 2 set, clear, anode set, clear)
*when we test out with the actual board, we can check if we really need to "clear"

display_tb.v:
1. the time DOES NOT update every clock cycle; this allows each of the 4 anodes to updated before the time changes